### PR TITLE
Add PeerGroup twirp service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/npxcomplete/caches v0.1.1
 	github.com/npxcomplete/random v0.0.0-20191215074600-22546b7becfe
 	github.com/stretchr/testify v1.4.0
+github.com/twitchtv/twirp v8.1.0+incompatible
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0 // indirect

--- a/src/mesh/peer-group.go
+++ b/src/mesh/peer-group.go
@@ -1,0 +1,56 @@
+package mesh
+
+import (
+	"context"
+
+	"github.com/twitchtv/twirp"
+)
+
+// PeerGroup implements a simple twirp service for managing peers.
+type PeerGroup struct {
+	hooks *twirp.ServerHooks
+}
+
+// NewPeerGroup creates a PeerGroup with default hooks.
+func NewPeerGroup() *PeerGroup {
+	return &PeerGroup{
+		hooks: &twirp.ServerHooks{},
+	}
+}
+
+// JoinPeerGroup registers a peer in the group.
+func (pg *PeerGroup) JoinPeerGroup(ctx context.Context, req *JoinPeerGroupRequest) (*JoinPeerGroupResponse, error) {
+	// TODO: add join logic
+	return &JoinPeerGroupResponse{Joined: true}, nil
+}
+
+// BroadcastUpdates sends updates to all members of the group.
+func (pg *PeerGroup) BroadcastUpdates(ctx context.Context, req *BroadcastUpdatesRequest) (*BroadcastUpdatesResponse, error) {
+	// TODO: add broadcast logic
+	return &BroadcastUpdatesResponse{Count: int32(len(req.Updates))}, nil
+}
+
+// JoinPeerGroupRequest represents a join request.
+type JoinPeerGroupRequest struct {
+	PeerId string
+}
+
+// JoinPeerGroupResponse represents a join response.
+type JoinPeerGroupResponse struct {
+	Joined bool
+}
+
+// BroadcastUpdatesRequest carries updates to send.
+type BroadcastUpdatesRequest struct {
+	Updates []string
+}
+
+// BroadcastUpdatesResponse contains acknowledgement info.
+type BroadcastUpdatesResponse struct {
+	Count int32
+}
+
+var _ interface {
+	JoinPeerGroup(context.Context, *JoinPeerGroupRequest) (*JoinPeerGroupResponse, error)
+	BroadcastUpdates(context.Context, *BroadcastUpdatesRequest) (*BroadcastUpdatesResponse, error)
+} = (*PeerGroup)(nil)

--- a/src/mesh/peer-group.proto
+++ b/src/mesh/peer-group.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package mesh;
+
+option go_package = "github.com/npxcomplete/http-rate-limit/src/mesh;mesh";
+
+service PeerGroup {
+    rpc JoinPeerGroup(JoinPeerGroupRequest) returns (JoinPeerGroupResponse);
+    rpc BroadcastUpdates(BroadcastUpdatesRequest) returns (BroadcastUpdatesResponse);
+}
+
+message JoinPeerGroupRequest {
+    string peer_id = 1;
+}
+
+message JoinPeerGroupResponse {
+    bool joined = 1;
+}
+
+message BroadcastUpdatesRequest {
+    repeated string updates = 1;
+}
+
+message BroadcastUpdatesResponse {
+    int32 count = 1;
+}


### PR DESCRIPTION
## Summary
- implement `PeerGroup` twirp service stub
- add `twitchtv/twirp` dependency
- add protobuf schema defining the PeerGroup service

## Testing
- `go vet ./...` *(fails: could not download modules)*
- `go test ./...` *(fails: could not download modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6880ffaff41c833092de667d9fecbdde