### PR TITLE
Add peer group map implementation

### DIFF
--- a/src/peergroup.go
+++ b/src/peergroup.go
@@ -1,0 +1,50 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// Capacity tracks rate limiting information for a peer.
+type Capacity struct {
+	Burst       uint32
+	Rate        uint32
+	Available   int64
+	LastUpdated time.Time
+	RecentSpend uint32
+}
+
+// PeerGroup manages capacity information for a set of peers using an
+// internal map keyed by peer identifier.
+type PeerGroup struct {
+	mu    sync.RWMutex
+	peers map[string]*Capacity
+}
+
+// NewPeerGroup creates a PeerGroup with no peers.
+func NewPeerGroup() *PeerGroup {
+	return &PeerGroup{peers: make(map[string]*Capacity)}
+}
+
+// Get returns the Capacity for the given peer id. The boolean return value
+// indicates whether a Capacity was present.
+func (g *PeerGroup) Get(id string) (*Capacity, bool) {
+	g.mu.RLock()
+	c, ok := g.peers[id]
+	g.mu.RUnlock()
+	return c, ok
+}
+
+// Set assigns the given Capacity to the peer id.
+func (g *PeerGroup) Set(id string, c *Capacity) {
+	g.mu.Lock()
+	g.peers[id] = c
+	g.mu.Unlock()
+}
+
+// Delete removes the peer from the group.
+func (g *PeerGroup) Delete(id string) {
+	g.mu.Lock()
+	delete(g.peers, id)
+	g.mu.Unlock()
+}

--- a/src/peergroup_test.go
+++ b/src/peergroup_test.go
@@ -1,0 +1,29 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPeerGroup_SetGetDelete(t *testing.T) {
+	pg := NewPeerGroup()
+	if _, ok := pg.Get("alice"); ok {
+		t.Fatalf("expected no entry")
+	}
+
+	c := &Capacity{Burst: 10, Rate: 5, Available: 5, LastUpdated: time.Now()}
+	pg.Set("alice", c)
+
+	rc, ok := pg.Get("alice")
+	if !ok {
+		t.Fatalf("expected entry to exist")
+	}
+	if rc != c {
+		t.Fatalf("returned capacity mismatch")
+	}
+
+	pg.Delete("alice")
+	if _, ok := pg.Get("alice"); ok {
+		t.Fatalf("expected entry removed")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a simple `PeerGroup` type backed by a map
- add basic tests for peer group behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881da071eac83309331116506dc8185